### PR TITLE
Add a PYTHON2 option

### DIFF
--- a/python-wrapper/CMakeLists.txt
+++ b/python-wrapper/CMakeLists.txt
@@ -1,5 +1,11 @@
+option(PYTHON2 "Lower the requirement for python to 2.7")
+if (PYTHON2)
+FIND_PACKAGE(PythonInterp 2.7)
+FIND_PACKAGE(PythonLibs 2.7)
+else()
 FIND_PACKAGE(PythonInterp 3.2)
 FIND_PACKAGE(PythonLibs 3.2)
+endif()
 # You should be able to compile python2 wrappers just by
 # decreasing the minimum required python version
 


### PR DESCRIPTION
This option is lowering the PYTHON2 requirment to 2.7. To use it
specify "-DPYTHON2=ON" on the cmake command line. I have no idea
how to make it so that "-DPYTHON2" would also work.