### PR TITLE
Bug fixes

### DIFF
--- a/python-wrapper/VariKN.i
+++ b/python-wrapper/VariKN.i
@@ -56,6 +56,7 @@
 
 %template(stringvector) std::vector<std::string>;
 %template(floatvector) std::vector<float>;
+%template(intvector) std::vector<int>;
 
 %feature("notabstract") InterTreeGram;
 %include Vocabulary.hh
@@ -72,4 +73,3 @@
 %}
 
 %template(VarigramTrainer) Varigram_t<int, int>;
-

--- a/src/VarigramFuncs.hh
+++ b/src/VarigramFuncs.hh
@@ -29,7 +29,7 @@ public:
   bool absolute;
   void write_vocab(FILE *out) {m_vocab->write(out);}
 
-  inline void write_file(std::string lmname, bool arpa) { io::Stream out(lmname, "w"); write(out.file, arpa); }
+  inline void write_file(std::string lmname, bool arpa) { io::Stream out(lmname, "w"); write(out.file, arpa); out.close(); }
 
 protected:
   bool m_use_3nzer;


### PR DESCRIPTION
Missing vector template prevented using set_cutoffs via Python interface. Varigram's write_file did not close the created file.
