### PR TITLE
add missing import to use shared_ptr correctly

### DIFF
--- a/src/PerplexityFuncs.hh
+++ b/src/PerplexityFuncs.hh
@@ -2,6 +2,7 @@
 #ifndef PERPLEXITY_HH
 #define PERPLEXITY_HH
 
+#include <memory>
 #include <deque>
 #include <iostream>
 #include <math.h>


### PR DESCRIPTION
g++ is unable to compile the PerplexityFunctions.cc without memory module. Include it in the header file.