### PR TITLE
count words also in the initial LM history

### DIFF
--- a/src/PerplexityFuncs.cc
+++ b/src/PerplexityFuncs.cc
@@ -181,6 +181,9 @@ float Perplexity::logprob(const char *word, float &cur_word_lp) {
 
   int idx = m_lm->word_index(word);
   if (m_cur_init_hist > 0) {
+    if (strncmp("<s>", word, 3) && is_wb(idx)) {
+      m_num_pwords++;
+    }
     m_cur_init_hist--;
     history.push_back(idx);
     m_lm->set_last_order(0);


### PR DESCRIPTION
Perplexity tool does not update word count when processing the initial LM history (--init_hist). This affects especially the case when a word break symbol is used after the sentence start symbol so that --init_hist=2 should be used. Example:

```
$ cat smalltest.token.w.txt 
<s> lorem ipsum dolor sit amet . </s>
$ perplexity -a words.arpa -t 1 smalltest.token.w.txt words.arpa.smalltest.ppl
$ cat words.arpa.smalltest.ppl

Dropped:   0 UNKS, 0.00 %
Processed: 7 words
Total:     7 words

Logprob -12.456325
Perplexity 60.18 (- 7th root) = 5.911 bits
Perplexity (sentence ends not in normalization) 119.14 (- 6th root) = 6.897 bits

Ngram hit rates:
1: 71.429
2: 14.286
3: 14.286

$ cat smalltest.token.c.txt 
<s> <w> l o r e m <w> i p s u m <w> d o l o r <w> s i t <w> a m e t <w> .  <w> </s>
$ echo '<w>' > wb.txt
$ perplexity -a chars.arpa -W wb.txt -t 2 smalltest.token.c.txt chars.arpa.smalltest.ppl
$ cat chars.arpa.smalltest.ppl

Dropped:   0 UNKS, 0.00 %
           0 TUNKS, 0.00 %
Processed: 6 words
           30 tokens
Total:     6 words
           30 tokens

Logprob -17.806987
Perplexity 928.61 (- 6th root) = 9.859 bits
Perplexity (sentence ends not in normalization) 3642.48 (- 5th root) = 11.831 bits

Tokenwise logprob -17.806987
Tokenwise perplexity 3.92 (- 30th root) = 1.972 bits

Ngram hit rates:
1: 0.000
2: 0.000
3: 100.000
```

After proposed fix:

```
$ cat chars.arpa.smalltest.ppl

Dropped:   0 UNKS, 0.00 %
           0 TUNKS, 0.00 %
Processed: 7 words
           30 tokens
Total:     7 words
           30 tokens

Logprob -17.806987
Perplexity 349.83 (- 7th root) = 8.451 bits
Perplexity (sentence ends not in normalization) 928.61 (- 6th root) = 9.859 bits

Tokenwise logprob -17.806987
Tokenwise perplexity 3.92 (- 30th root) = 1.972 bits

Ngram hit rates:
1: 0.000
2: 0.000
3: 100.000
```
