### PR TITLE
add more public methods for Perplexity class

### DIFF
--- a/src/PerplexityFuncs.hh
+++ b/src/PerplexityFuncs.hh
@@ -29,6 +29,17 @@ public:
     float tmp;
     return logprob(word, tmp);
   };
+  inline float word_logprob(const char *word) {
+    float tmp, lp = 0;
+    logprob(word, lp);
+    return lp;
+  };
+  inline int processed_tokens() {
+    return m_num_ptokens;
+  };
+  inline int processed_words() {
+    return m_num_pwords;
+  };
   float sentence_logprob(const char *sentence);
   void print_hitrates(FILE *out);
   double print_results(FILE *out);
@@ -52,6 +63,7 @@ public:
   void reset_hitrates();
   int get_hitorder(int i);
 
+  void init_variables();
   void clear_history() {
     history.clear();
     m_cur_init_hist = m_init_hist;
@@ -69,7 +81,6 @@ private:
 
   void find_indices(const std::string, std::vector<int> &);
   void load_mbs(const std::string, std::vector<std::string> &);
-  void init_variables();
   void init_special_symbols(const std::string ccs_name,
                             const std::string wb_name,
                             const std::string mb_name);


### PR DESCRIPTION
Add word_logprob, processed_words, and processed_tokens and make
init_variables public to enable more features for the python wrapper.

Example: For calculating word-based perplexity for each line, you can do something like this:
```
lm = varikn.Perplexity(...)
for idx, line in enumerate(lines):
    lpsum = 0.0
    for token in line.split():
        lpsum += lm.word_logprob(token)
    ppl = 10**(-lpsum / lm.processed_words())
    print("Perplexity for line {}: {}".format(idx, ppl))
    lm.clear_history()
    lm.init_variables()
```
